### PR TITLE
fix: Container.stats for non-stream mode

### DIFF
--- a/podman/domain/containers.py
+++ b/podman/domain/containers.py
@@ -419,7 +419,7 @@ class Container(PodmanResource):
 
         with io.StringIO() as buffer:
             for entry in response.text:
-                buffer.writer(json.dumps(entry) + "\n")
+                buffer.write(json.dumps(entry) + "\n")
             return buffer.getvalue()
 
     @staticmethod


### PR DESCRIPTION
In non-stream mode, container.stats should work now
(fixing incorrect call of StringIO.writer instead of StringIO.write).